### PR TITLE
Added absolute mode for map zoom level using wheel.

### DIFF
--- a/HORUS/SOURCES/SRC/SCRIPTS/TOOLS/Yaapu Config.lua
+++ b/HORUS/SOURCES/SRC/SCRIPTS/TOOLS/Yaapu Config.lua
@@ -98,6 +98,7 @@ local menuItems = {
   {"GPS coordinates format:", "GPS", 1, { "DMS", "decimal" }, { 1, 2 } },
   {"map provider:", "MAPP", 1, { "GMapCatcher", "Google" }, { 1, 2 } },
   {"map type:", "MAPT", 1, { "satellite", "map", "terrain" }, { "sat_tiles", "tiles", "ter_tiles" } },
+  {"map emulated wheel mode:", "MAPWM", 1, { "incremental", "absolute" }, { 1, 2 } },
   {"map zoom level default value:", "MAPZ", -2, -2, 17,nil,0,1 },
   {"map zoom level min value:", "MAPmZ", -2, -2, 17,nil,0,1 },
   {"map zoom level max value:", "MAPMZ", 17, -2, 17,nil,0,1 },
@@ -402,6 +403,7 @@ local function applyConfigValues(conf)
   conf.enableRPM = getMenuItemByName(menuItems,"RPM")
   conf.enableWIND = getMenuItemByName(menuItems,"WIND")
 
+  conf.mapWheelMode = getMenuItemByName(menuItems,"MAPWM")
   conf.mapZoomLevel = getMenuItemByName(menuItems,"MAPZ")
   conf.mapZoomMin = getMenuItemByName(menuItems,"MAPmZ")
   conf.mapZoomMax = getMenuItemByName(menuItems,"MAPMZ")

--- a/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/menu.lua
+++ b/HORUS/SOURCES/SRC/SCRIPTS/YAAPU/menu.lua
@@ -98,6 +98,7 @@ local menuItems = {
   {"GPS coordinates format:", "GPS", 1, { "DMS", "decimal" }, { 1, 2 } },
   {"map provider:", "MAPP", 1, { "GMapCatcher", "Google" }, { 1, 2 } },
   {"map type:", "MAPT", 1, { "satellite", "map", "terrain" }, { "sat_tiles", "tiles", "ter_tiles" } },
+  {"map emulated wheel mode:", "MAPWM", 1, { "incremental", "absolute" }, { 1, 2 } },
   {"map zoom level default value:", "MAPZ", -2, -2, 17,nil,0,1 },
   {"map zoom level min value:", "MAPmZ", -2, -2, 17,nil,0,1 },
   {"map zoom level max value:", "MAPMZ", 17, -2, 17,nil,0,1 },
@@ -402,6 +403,7 @@ local function applyConfigValues(conf)
   conf.enableRPM = getMenuItemByName(menuItems,"RPM")
   conf.enableWIND = getMenuItemByName(menuItems,"WIND")
 
+  conf.mapWheelMode = getMenuItemByName(menuItems,"MAPWM")
   conf.mapZoomLevel = getMenuItemByName(menuItems,"MAPZ")
   conf.mapZoomMin = getMenuItemByName(menuItems,"MAPmZ")
   conf.mapZoomMax = getMenuItemByName(menuItems,"MAPMZ")

--- a/HORUS/SOURCES/SRC/WIDGETS/Yaapu/main.lua
+++ b/HORUS/SOURCES/SRC/WIDGETS/Yaapu/main.lua
@@ -2436,19 +2436,35 @@ utils.getMapZoomLevel = function(myWidget,conf,status,chValue)
   zoomDelayStart = now
 
   if conf.screenWheelChannelId > -1 then
-    -- SW up (increase zoom level)
-    if chValue < -600 then
-      if conf.mapProvider == 1 then
-        return status.mapZoomLevel > conf.mapZoomMin and status.mapZoomLevel - 1 or status.mapZoomLevel
-      end
-      return status.mapZoomLevel < conf.mapZoomMax and status.mapZoomLevel + 1 or status.mapZoomLevel
-    end
-    -- SW down (decrease zoom level)
-    if chValue > 600 then
-      if conf.mapProvider == 1 then
+    -- Incremental wheel mode (default) 
+    if conf.mapWheelMode == 1 then
+      -- SW up (increase zoom level)
+      if chValue < -600 then
+        if conf.mapProvider == 1 then
+          return status.mapZoomLevel > conf.mapZoomMin and status.mapZoomLevel - 1 or status.mapZoomLevel
+        end
         return status.mapZoomLevel < conf.mapZoomMax and status.mapZoomLevel + 1 or status.mapZoomLevel
       end
-      return status.mapZoomLevel > conf.mapZoomMin and status.mapZoomLevel - 1 or status.mapZoomLevel
+      -- SW down (decrease zoom level)
+      if chValue > 600 then
+        if conf.mapProvider == 1 then
+          return status.mapZoomLevel < conf.mapZoomMax and status.mapZoomLevel + 1 or status.mapZoomLevel
+        end
+        return status.mapZoomLevel > conf.mapZoomMin and status.mapZoomLevel - 1 or status.mapZoomLevel
+      end
+    end
+
+    -- Absolute wheel mode (default) 
+    -- Devide the channel width to N steps where N is the number of zoom levels
+    -- between minimum and maximum zoom.
+    -- Set the zoom level according to the respective step the channel falls into
+    if conf.mapWheelMode == 2 then
+      local levels = conf.mapZoomMax - conf.mapZoomMin
+      local step = math.floor(2000 / levels)
+      local normChannel = 1000 + chValue
+      local zoomOffset = math.floor(normChannel / step)
+
+      return conf.mapZoomMin + zoomOffset
     end
     -- switch is idle, force timer expire
     zoomDelayStart = now - conf.screenWheelChannelDelay*10


### PR DESCRIPTION
Zomming in and out is great if you map the wheel to a 3 position channel, but feels a bit awkward if using with a knob. 
It is a lot more convenient to have a rotary switch which is divided into sections based on the number of zoom levels you have in your config.

This will allow to pick a zoom level based on the switch position which feel much better in my opinion.