### PR TITLE
yaapu9.lua: look for Soundsequence ##S: ##N:

### DIFF
--- a/OTX_ETX/bw212x64_f4/SRC/yaapu9.lua
+++ b/OTX_ETX/bw212x64_f4/SRC/yaapu9.lua
@@ -730,10 +730,26 @@ local function processTelemetry(appId, value, now)
       end
       doGarbageCollect()
       if msgEnd then
-        -- push and display message
-        local severity = (bit32.extract(value,7,1) * 1) + (bit32.extract(value,15,1) * 2) + (bit32.extract(value,23,1) * 4)
-        pushMessage( severity, msgBuffer)
-        playHash()
+        -- check, if special sequence ##S: and/or ##N: in message
+          -- CAUTION: If both, in every case first Sound then Number will be announced!!
+        local patternfound = false
+        local param = string.match(msgBuffer, ".*##S:([a-zA-Z_]+).*")-- e.g. ##SSelectedMission
+        if param then
+          patternfound = true
+          playSound(param)
+        end
+        param = string.match(msgBuffer, ".*##N:([0-9]+).*") -- e.g. ##N002
+        if param then
+          patternfound = true
+          playNumber(tonumber(param),0)
+        end
+        if patternfound == false then
+          -- push and display message
+          local severity = (bit32.extract(value,7,1) * 1) + (bit32.extract(value,15,1) * 2) + (bit32.extract(value,23,1) * 4)
+          pushMessage( severity, msgBuffer)
+          playHash()
+        end
+
         resetHash()
         msgBuffer = nil
         -- recover memory
@@ -1391,7 +1407,7 @@ local bgclock = 0
 -------------------------------
 local function background()
   local now = getTime()
-   
+  
   -- FAST: this runs at 60Hz (every 16ms)
   for i=1,7
   do
@@ -1634,7 +1650,7 @@ local function init()
   clearTable(menuLib)
   menuLib = nil
 
-  pushMessage(7,"Yaapu 2.0.0-dev".." ("..'ae68d48'..")")
+  pushMessage(7,"Yaapu 2.0.0-devW".." ("..'ae68d48'..")")
   doGarbageCollect()
   playSound("yaapu")
 end


### PR DESCRIPTION
scan messages against sequence ##S:soundfile and/or ##N:number and
play sound(s) accordingly, but don't display the message

Successfully tested on OpenTX Companion and (precompiled) on real X9E(02/2017)

As first step only implemented in yaapu9.lua (as draft) to show you my idea. 
It's very helpful for all ArduPilot scripts to announce sounds and  numbers on yaapu GCS.

I had the idea after realizing my SwitchMission script, where it's possible to select one of an undefined number of missions via upcount/restart pushbutton. Before that change you had to look at the display to select a preferred mission.

In **AP script**, the message is created by: 
local function sound_to_yaapu(sound,number) -- sound or number has to be nil to be ignored
  -- send a message to the yaapu-GCS containing a name of a soundfile and/or a number, to announce (not to display) there
  if YAAPU:get()==0 then return end
  if sound and number then
    send_msg(INFO, string.format('##S:%s ##N:%02.2u', sound, number))
    return
  end
  if sound then
    send_msg(INFO, string.format('##S:%s', sound))
    return
  end
  if number then
    send_msg(INFO, string.format('##N:%02.2u', number))
  end
end
